### PR TITLE
Add inspect linkages test

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,8 @@ requirements:
 test:
     imports:
         - pandas
+    commands:
+        - conda inspect linkages -n _test pandas  # [linux]
 
 about:
     home: http://pandas.pydata.org


### PR DESCRIPTION
Ideally we should always run this test when there is a `cython` extension.