### PR TITLE
Build packages for numpy 1.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,17 @@
 language: generic
 
 os: osx
-osx_image: beta-xcode6.1
+osx_image: xcode6.4
 
 env:
   matrix:
     
-    - CONDA_NPY=110  CONDA_PY=27
     - CONDA_NPY=111  CONDA_PY=27
-    - CONDA_NPY=110  CONDA_PY=34
-    - CONDA_NPY=111  CONDA_PY=34
-    - CONDA_NPY=110  CONDA_PY=35
+    - CONDA_NPY=112  CONDA_PY=27
     - CONDA_NPY=111  CONDA_PY=35
+    - CONDA_NPY=112  CONDA_PY=35
     - CONDA_NPY=111  CONDA_PY=36
+    - CONDA_NPY=112  CONDA_PY=36
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "azJjQJJ3AwRWcueVlo7EyYPB5ls04Vx8IkYVIfLoRc84NJ1aePU2B15gBaHROPx9jrDHcVzfWLKaq+qj19C1kMUViIgxeMJ/+2kst8d2TrPoVy9fiHRWUnim/MNluUhBfnXxyeLxnWbJX4pBJBOpAiU1wi+WO/d88EWxfx2aPhQfiEXuD+j66mGYmOVrZ2mwPDVKFOp+8r9bmT9OE162HKJEepVcWiNi+wR58rp91wV3rA18Ouwzw1AmuQb88l3bdKjN8h2pAbIKOopDTv4pU89hLd3HqPkyAuTF67dSQzliMhZBjpl9C0468GH+rs7/EUUqoZIVMNRpZ4j6clqwDf/GB49bUnUZlbLavkqkbyK4NdLIX2zu9iWWQkpXVj0VZDCyFBsRqjOcElM6nO7NhRfBMVrdUgzVFLID24G58u/qMKORpX6d17t5e9baNRBDhe/3cRokB1et681g8iFKRmVdhJ+wCvbMx6KjEVP6csAV46713PoNGv9GUx4utJyLx/ttlxrGLMFcix6mpZV3kBRfk2prySzuZ3DvVqIRpujiPK+3XvIUPXIfxmsFmf9nxPJ05GQ4FcLBC81wKmbd+icCrPVwGZyUaHqGfNaBM06av/6FcAa+8muMiz8CnLJb3d7rknJKrexXTAYdCPH7mHLHDFUqE6+gfSY222jP1zs="
@@ -23,31 +22,38 @@ env:
 
 before_install:
     # Remove homebrew.
-    - brew remove --force $(brew list)
-    - brew cleanup -s
-    - rm -rf $(brew --cache)
+    - |
+      echo ""
+      echo "Removing homebrew from Travis CI to avoid conflicts."
+      curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > ~/uninstall_homebrew
+      chmod +x ~/uninstall_homebrew
+      ~/uninstall_homebrew -fq
+      rm ~/uninstall_homebrew
+
 
 install:
+    # Install Miniconda.
     - |
+      echo ""
+      echo "Installing a fresh version of Miniconda."
       MINICONDA_URL="https://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
       curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
+    # Configure conda.
+    - |
+      echo ""
+      echo "Configuring conda."
       source /Users/travis/miniconda3/bin/activate root
+      conda config --remove channels defaults
+      conda config --add channels defaults
       conda config --add channels conda-forge
       conda config --set show_channel_urls true
       conda install --yes --quiet conda-forge-build-setup
       source run_conda_forge_build_setup
 
-      # install conda-build 2.x to build with a long prefix
-      conda install --yes --quiet conda-build=2
-      conda info
-
 script:
   - conda build ./recipe
 
   - upload_or_check_non_existence ./recipe conda-forge --channel=main
-
-  # inspect the prefix lengths of the built packages
-  - conda inspect prefix-lengths /Users/travis/miniconda3/conda-bld/osx-64/*.tar.bz2

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 BSD 3-clause license
-Copyright (c) conda-forge
+Copyright (c) 2015-2017, conda-forge
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,16 +15,6 @@ environment:
 
   matrix:
     - TARGET_ARCH: x86
-      CONDA_NPY: 110
-      CONDA_PY: 27
-      CONDA_INSTALL_LOCN: C:\\Miniconda
-
-    - TARGET_ARCH: x64
-      CONDA_NPY: 110
-      CONDA_PY: 27
-      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
-
-    - TARGET_ARCH: x86
       CONDA_NPY: 111
       CONDA_PY: 27
       CONDA_INSTALL_LOCN: C:\\Miniconda
@@ -33,36 +23,6 @@ environment:
       CONDA_NPY: 111
       CONDA_PY: 27
       CONDA_INSTALL_LOCN: C:\\Miniconda-x64
-
-    - TARGET_ARCH: x86
-      CONDA_NPY: 110
-      CONDA_PY: 34
-      CONDA_INSTALL_LOCN: C:\\Miniconda3
-
-    - TARGET_ARCH: x64
-      CONDA_NPY: 110
-      CONDA_PY: 34
-      CONDA_INSTALL_LOCN: C:\\Miniconda3-x64
-
-    - TARGET_ARCH: x86
-      CONDA_NPY: 111
-      CONDA_PY: 34
-      CONDA_INSTALL_LOCN: C:\\Miniconda3
-
-    - TARGET_ARCH: x64
-      CONDA_NPY: 111
-      CONDA_PY: 34
-      CONDA_INSTALL_LOCN: C:\\Miniconda3-x64
-
-    - TARGET_ARCH: x86
-      CONDA_NPY: 110
-      CONDA_PY: 35
-      CONDA_INSTALL_LOCN: C:\\Miniconda35
-
-    - TARGET_ARCH: x64
-      CONDA_NPY: 110
-      CONDA_PY: 35
-      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
 
     - TARGET_ARCH: x86
       CONDA_NPY: 111
@@ -77,12 +37,12 @@ environment:
     - TARGET_ARCH: x86
       CONDA_NPY: 111
       CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda
+      CONDA_INSTALL_LOCN: C:\\Miniconda35
 
     - TARGET_ARCH: x64
       CONDA_NPY: 111
       CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
+      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
 
 
 # We always use a 64-bit machine, but can build x86 distributions
@@ -104,30 +64,22 @@ install:
     # Cywing's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
     - cmd: rmdir C:\cygwin /s /q
 
-    # Add our channels.
-    - cmd: set "OLDPATH=%PATH%"
-    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
-    - cmd: conda config --set show_channel_urls true
-    - cmd: conda config --add channels conda-forge
-
-    # Add a hack to switch to `conda` version `4.1.12` before activating.
-    # This is required to handle a long path activation issue.
-    # Please see PR ( https://github.com/conda/conda/pull/3349 ).
-    - cmd: conda install --yes --quiet conda=4.1.12
-    - cmd: set "PATH=%OLDPATH%"
-    - cmd: set "OLDPATH="
-
-    # Actually activate `conda`.
+    # Add path, activate `conda` and update conda.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
+    - cmd: conda update --yes --quiet conda
+
     - cmd: set PYTHONUNBUFFERED=1
 
+    # Add our channels.
+    - cmd: conda config --set show_channel_urls true
+    - cmd: conda config --remove channels defaults
+    - cmd: conda config --add channels defaults
+    - cmd: conda config --add channels conda-forge
+
+    # Configure the VM.
     - cmd: conda install -n root --quiet --yes obvious-ci
     - cmd: conda install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
-
-    # install conda-build 2.x to build a long prefix
-    - cmd: conda install --yes --quiet conda-build=2
-    - cmd: conda info
 
 # Skip .NET project specific build phase.
 build: off

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -14,7 +14,7 @@ config=$(cat <<CONDARC
 
 channels:
  - conda-forge
- - defaults # As we need conda-build
+ - defaults
 
 conda-build:
  root-dir: /feedstock_root/build_artefacts
@@ -25,8 +25,8 @@ CONDARC
 )
 
 cat << EOF | docker run -i \
-                        -v ${RECIPE_ROOT}:/recipe_root \
-                        -v ${FEEDSTOCK_ROOT}:/feedstock_root \
+                        -v "${RECIPE_ROOT}":/recipe_root \
+                        -v "${FEEDSTOCK_ROOT}":/feedstock_root \
                         -a stdin -a stdout -a stderr \
                         condaforge/linux-anvil \
                         bash || exit $?
@@ -41,18 +41,7 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
-# install conda-build 2.x to build a long prefix
-conda install --yes --quiet conda-build=2
-conda info
-
-# Embarking on 7 case(s).
-    set -x
-    export CONDA_NPY=110
-    export CONDA_PY=27
-    set +x
-    conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
-
+# Embarking on 6 case(s).
     set -x
     export CONDA_NPY=111
     export CONDA_PY=27
@@ -61,28 +50,21 @@ conda info
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
 
     set -x
-    export CONDA_NPY=110
-    export CONDA_PY=34
+    export CONDA_NPY=112
+    export CONDA_PY=27
     set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
 
     set -x
     export CONDA_NPY=111
-    export CONDA_PY=34
-    set +x
-    conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
-
-    set -x
-    export CONDA_NPY=110
     export CONDA_PY=35
     set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
 
     set -x
-    export CONDA_NPY=111
+    export CONDA_NPY=112
     export CONDA_PY=35
     set +x
     conda build /recipe_root --quiet || exit 1
@@ -95,6 +77,10 @@ conda info
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
 
-# inspect the prefix lengths of the built packages
-conda inspect prefix-lengths /feedstock_root/build_artefacts/linux-64/*.tar.bz2
+    set -x
+    export CONDA_NPY=112
+    export CONDA_PY=36
+    set +x
+    conda build /recipe_root --quiet || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
 EOF

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 source:
   fn: pandas-{{ version }}.tar.gz
   url: https://github.com/pydata/pandas/archive/v{{ version }}.tar.gz
-  sha256: dd2ee30e21804675a6ef41bea854a023b8be3b840fd2aa33e7e1cc38066e781c
+  sha256: af634dd6ed3ca1f8635183f41e7f7769108531ccca8213067d9627857461702e
 
 build:
   number: 1


### PR DESCRIPTION
Rerender feedstock to add numpy 1.12 to the build configuration.

I kept the build number the same as the recipe did not change.