### PR TITLE
Add 'recommended' dependencies bottleneck & numexpr

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,8 @@ requirements:
     - numpy  x.x
     - python-dateutil
     - pytz
+    - bottleneck
+    - numexpr
 
 test:
   imports:


### PR DESCRIPTION
http://pandas.pydata.org/pandas-docs/stable/install.html#recommended-dependencies
Docs recommend numexpr & bottleneck for performance reasons.