### PR TITLE
Pin python dateutils

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 84ab1d50590cb2d9554211f164dc1b1a216bc94da2ba922aed2690c83f248fd9
 
 build:
-  number: 0
+  number: 1
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - python
     - numpy >=1.9.*  # [py27 or py35]
     - numpy >=1.11.*  # [py36]
-    - python-dateutil
+    - python-dateutil >=2.5.*
     - pytz
 
 test:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Fixes the following problem, where pandas expects at least dateutils 2.5.0

```bash
conda create -n pandas-test pandas -c conda-forge
source activate pandas-test
python -c 'import pandas'
```
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/miniconda3/envs/pandas-test/lib/python3.5/site-packages/pandas/__init__.py", line 23, in <module>
    from pandas.compat.numpy import *
  File "/miniconda3/envs/pandas-test/lib/python3.5/site-packages/pandas/compat/__init__.py", line 421, in <module>
    raise ImportError('dateutil 2.5.0 is the minimum required version')
ImportError: dateutil 2.5.0 is the minimum required version
```