### PR TITLE
Use NumPy 1.23 or earlier for testing

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 220b98d15cee0b2cd839a6358bd1f273d0356bf964c1a1aeb32d47db0215488b
 
 build:
-  number: 1
+  number: 2
   script:
     - export PYTHONUNBUFFERED=1  # [ppc64le]
     - {{ PYTHON }} -m pip install -vv --no-deps --ignore-installed .  # [not unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -60,6 +60,9 @@ test:
     - pytest-cov
     - boto3
     - hypothesis
+    # Workaround recent NumPy 1.24 deprecations, which cause test failures.
+    # xref: https://github.com/conda-forge/pandas-feedstock/issues/150
+    - numpy <1.24
     - psutil
     - tomli  # [py<311]
 


### PR DESCRIPTION
Skip using NumPy 1.24 in testing since this results in deprecation warnings that get turned into test failures. Instead use NumPy 1.23 or earlier, which do not have this issue.

xref: https://github.com/conda-forge/pandas-feedstock/issues/150

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
