### PR TITLE
DO NOT MERGE: Run CI to debug ppc64le problem

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 74a3fd7e5a7ec052f183273dc7b0acd3a863edf7520f5d3a1765c04ffdb3b0b1
 
 build:
-  number: 0
+  number: 1
   script:
     - export PYTHONUNBUFFERED=1  # [ppc64le]
     - {{ PYTHON }} -m pip install -vv --no-deps --ignore-installed .  # [not unix]


### PR DESCRIPTION
DO NOT MERGE PLEASE.

Just opening to get the log of the ppc64le from the CI, which is not available anymore.