### PR TITLE
Add jinja2 as a dependency

### DIFF
--- a/.ci_support/linux_64_python3.14.____cp314.yaml
+++ b/.ci_support/linux_64_python3.14.____cp314.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge,conda-forge/label/python_rc
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -31,5 +31,3 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-- - python
-  - channel_sources

--- a/.ci_support/linux_aarch64_python3.14.____cp314.yaml
+++ b/.ci_support/linux_aarch64_python3.14.____cp314.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge,conda-forge/label/python_rc
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -31,5 +31,3 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-- - python
-  - channel_sources

--- a/.ci_support/linux_ppc64le_python3.14.____cp314.yaml
+++ b/.ci_support/linux_ppc64le_python3.14.____cp314.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge,conda-forge/label/python_rc
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -31,5 +31,3 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-- - python
-  - channel_sources

--- a/.ci_support/osx_64_python3.14.____cp314.yaml
+++ b/.ci_support/osx_64_python3.14.____cp314.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '10.13'
 channel_sources:
-- conda-forge,conda-forge/label/python_rc
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -35,5 +35,3 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-- - python
-  - channel_sources

--- a/.ci_support/osx_arm64_python3.14.____cp314.yaml
+++ b/.ci_support/osx_arm64_python3.14.____cp314.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge,conda-forge/label/python_rc
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -35,5 +35,3 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-- - python
-  - channel_sources

--- a/.ci_support/win_64_python3.14.____cp314.yaml
+++ b/.ci_support/win_64_python3.14.____cp314.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge,conda-forge/label/python_rc
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -20,6 +20,3 @@ python_impl:
 - cpython
 target_platform:
 - win-64
-zip_keys:
-- - python
-  - channel_sources

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b
 
 build:
-  number: 1
+  number: 2
   script:
     - export PYTHONUNBUFFERED=1  # [ppc64le]
     # Cross-compilation stuff vendored from numpy-feedstock

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,6 +58,7 @@ requirements:
     - fsspec >=2022.11.0
     - gcsfs >=2022.11.0
     - html5lib >=1.1
+    - jinja2 >=3.1.5
     - lxml >=4.9.2
     - matplotlib >=3.6.3
     - numba >=0.56.4


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Not sure if there was a reason jinja2 was not included as a dependency here since we have a lot of the other optional dependencies already (tabulate, for example is the other from the `output-formatting` optional group).